### PR TITLE
Fix unlocked items message with new load messages

### DIFF
--- a/A3A/addons/scrt/Arsenal/fn_arsenal_loadoutArsenal.sqf
+++ b/A3A/addons/scrt/Arsenal/fn_arsenal_loadoutArsenal.sqf
@@ -2571,6 +2571,8 @@ switch _mode do {
 			case IDC_RSCDISPLAYARSENAL_TAB_BACKPACK: {loadbackpack player};
 		};
 
+		_ctrlLoadCargo progresssetposition _load;
+
 		if (_loadOld isNotEqualTo _load) then {
 			_amountOld = parseNumber (_ctrlList lnbtext [_lbcursel,2]);
 			if(_add > 0)then{
@@ -2580,43 +2582,41 @@ switch _mode do {
 				_ctrlList lnbsettext [[_lbcursel,2],str (_amountOld - _count)];
 				[_index, _item, _count] call jn_fnc_arsenal_addItem;
 			};
-		};
 
-		_load = switch _selected do{
-			case IDC_RSCDISPLAYARSENAL_TAB_UNIFORM: {[loaduniform player, getContainerMaxLoad uniform player, "STR_antistasi_dialogs_hq_button_rebel_loadouts_container_uniform"]};
-			case IDC_RSCDISPLAYARSENAL_TAB_VEST: {[loadvest player, getContainerMaxLoad vest player, "STR_antistasi_dialogs_hq_button_rebel_loadouts_container_vest"]};
-			case IDC_RSCDISPLAYARSENAL_TAB_BACKPACK: {[loadbackpack player, getContainerMaxLoad backpack player, "STR_antistasi_dialogs_hq_button_rebel_loadouts_container_backpack"]};
-		};
-
-		_ctrlLoadCargo progresssetposition (_load select 0);
-
-		if (_loadOld isNotEqualTo _load) then {
-			private _loadPercentage = load player;
-			private _loadAbs = loadAbs player;
-			private _loadLimit = getNumber(configFile >> "CfgInventoryGlobalVariable" >> "maxSoldierLoad");
-			private _message = [];
-
-			_message pushBack format["%1 %2%3 (%4/%5)", 
-				localize "STR_antistasi_dialogs_hq_button_rebel_loadouts_load_caption", 
-				(_loadPercentage * 100) toFixed 1, "%", _loadAbs, _loadLimit
-			];
-
-			switch true do {
-				case (_loadPercentage >= 1): {
-					_message pushBack localize "STR_antistasi_dialogs_hq_button_rebel_loadouts_overload_fatal";
-					playSound "A3AP_UiFailure";
-				};
-				case (_loadPercentage >= 0.8): {
-					_message pushBack localize "STR_antistasi_dialogs_hq_button_rebel_loadouts_overload_warning";
-				};
+			_load = switch _selected do{
+				case IDC_RSCDISPLAYARSENAL_TAB_UNIFORM: {[loaduniform player, getContainerMaxLoad uniform player, "STR_antistasi_dialogs_hq_button_rebel_loadouts_container_uniform"]};
+				case IDC_RSCDISPLAYARSENAL_TAB_VEST: {[loadvest player, getContainerMaxLoad vest player, "STR_antistasi_dialogs_hq_button_rebel_loadouts_container_vest"]};
+				case IDC_RSCDISPLAYARSENAL_TAB_BACKPACK: {[loadbackpack player, getContainerMaxLoad backpack player, "STR_antistasi_dialogs_hq_button_rebel_loadouts_container_backpack"]};
 			};
 
-			_message pushBack format["%1: %2%3 (%4/%5)", localize(_load select 2), 
-				(100 * (_load select 0)) toFixed 1, "%",
-				((_load select 0) * (_load select 1)) toFixed 1, _load select 1
-			];
+			if (_loadOld isNotEqualTo _load) then {
+				private _loadPercentage = load player;
+				private _loadAbs = loadAbs player;
+				private _loadLimit = getNumber(configFile >> "CfgInventoryGlobalVariable" >> "maxSoldierLoad");
+				private _message = [];
 
-			['showMessage',[_display, _message joinString " | "]] call SCRT_fnc_arsenal_loadoutArsenal;
+				_message pushBack format["%1 %2%3 (%4/%5)", 
+					localize "STR_antistasi_dialogs_hq_button_rebel_loadouts_load_caption", 
+					(_loadPercentage * 100) toFixed 1, "%", _loadAbs, _loadLimit
+				];
+
+				switch true do {
+					case (_loadPercentage >= 1): {
+						_message pushBack localize "STR_antistasi_dialogs_hq_button_rebel_loadouts_overload_fatal";
+						playSound "A3AP_UiFailure";
+					};
+					case (_loadPercentage >= 0.8): {
+						_message pushBack localize "STR_antistasi_dialogs_hq_button_rebel_loadouts_overload_warning";
+					};
+				};
+
+				_message pushBack format["%1: %2%3 (%4/%5)", localize(_load select 2), 
+					(100 * (_load select 0)) toFixed 1, "%",
+					((_load select 0) * (_load select 1)) toFixed 1, _load select 1
+				];
+
+				['showMessage',[_display, _message joinString " | "]] call SCRT_fnc_arsenal_loadoutArsenal;
+			};
 		};
 
 		["SelectItemRight",[_display,_ctrlList,_index]] call SCRT_fnc_arsenal_loadoutArsenal;


### PR DESCRIPTION
## What type of PR is this?
- [x] Bug
- [ ] Change
- [ ] Feature
- [ ] Miscellaneous

<details><summary><i><b>
Sub-categories:
</b></i></summary>

- [ ] Template
- [ ] Map
- [ ] Config
- [x] Function
- [ ] Localization

</details>

## What have you changed, and why?

**Information:**

> Fixes the display of the message "Only unlocked items can be used" in the arsenal / prevents it being overwritten by the load message when load hasn't changed. See comments in #643. 

Specific test case is attempting to add a non-unlocked RPG rocket to a backpack.

Submitting as a PR because Github won't let me put it as a review comment suggestion due to line breaks of non-changed code in the original PR. All it does is re-order / conditionalize a couple things.

**How can your changes be tested, or reproduced?**

> ...

**Does this PR include changes not authored by you?**

- [ ] No
- [x] Yes (See below)

<details><summary><i><b>
Further info: you lol
</b></i></summary><br>

- [x] I confirm that I, and by extension this repository, can legally use these third-party changes. (Provide links or author attribution.)

> ...

</details>

## Please verify the following (If possible).

`*` - Mandatory

- [x] These changes are my own, or I have written permission to use them. `*`
- [x] These changes are ready for review, or will be marked as a draft. `*`
- [x] I have loaded the mission in LAN host.
- [ ] I have loaded the mission on a dedicated server.

Is further work needed?

- [x] Needs further testing.
- [ ] Needs further changes.
- [ ] Needs to be converted to a draft.

## Please specify which Issue this PR Resolves (If Applicable).
This PR closes #XYZ.

<hr><details><summary><i><b>
Notes:
</b></i></summary><br>

> ...

</details>